### PR TITLE
Fix crash on remove cells

### DIFF
--- a/Example/SelfTableViewManager/Info.plist
+++ b/Example/SelfTableViewManager/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.4</string>
+	<string>5.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/Tests/Info.plist
+++ b/Example/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.4</string>
+	<string>5.1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -190,7 +190,6 @@ final class Tests: XCTestCase {
         table.tableView(table, didEndDisplaying: UITableViewCell(), forRowAt: IndexPath(row: 0, section: 0))
         XCTAssertEqual(mock.didEndDisplaying, true)
     }
-
     
     func testViewCodeCellLoadDefaultCellForTableShouldReturnCorrectView() {
         let viewCodeCell = ViewCodeCell(bundle: Bundle(for: ViewCodeCellView.self).bundleURL.absoluteString)

--- a/SelfTableViewManager.podspec
+++ b/SelfTableViewManager.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'SelfTableViewManager'
-  s.version          = '5.1.4'
+  s.version          = '5.1.5'
   s.summary          = 'Um jeito simples de criar e manipular uma TableView.'
 
   s.description      = <<-DESC

--- a/SelfTableViewManager/Classes/SelfTableViewManager.swift
+++ b/SelfTableViewManager/Classes/SelfTableViewManager.swift
@@ -476,10 +476,11 @@ open class CellController: NSObject {
     var tag: Int?
     var bundleURL: String?
     
-    private var bundle: Bundle? {
+    private var bundle: Bundle {
         guard let bundleURL = bundleURL,
-              let url = URL(string: bundleURL) else { return Bundle(for: type(of: self)) }
-        return Bundle(url: url)
+              let url = URL(string: bundleURL),
+              let bundle = Bundle(url: url) else { return Bundle(for: type(of: self)) }
+        return bundle
     }
 
     deinit {
@@ -517,7 +518,7 @@ open class CellController: NSObject {
         
         if cell == nil {
             let path = reuseIdentifier()
-            let shouldLoadNib = bundle?.path(forResource: path, ofType: "nib") != nil
+            let shouldLoadNib = bundle.path(forResource: path, ofType: "nib") != nil
             if shouldLoadNib {
                 _ = SelfTableViewManagerCache.shared().loadNib(path: path, owner: self, bundleURL: bundleURL)
                 cell = controllerCell;
@@ -610,10 +611,11 @@ open class SectionController: NSObject {
     var tableView: UITableView?
     var bundleURL: String?
     
-    private var bundle: Bundle? {
+    private var bundle: Bundle {
         guard let bundleURL = bundleURL,
-              let url = URL(string: bundleURL) else { return Bundle(for: type(of: self)) }
-        return Bundle(url: url)
+              let url = URL(string: bundleURL),
+              let bundle = Bundle(url: url) else { return Bundle(for: type(of: self)) }
+        return bundle
     }
     
     deinit {
@@ -645,7 +647,7 @@ open class SectionController: NSObject {
         let sectionName = customSectionName()
         
         let sectionView: SectionView
-        let isNibFileExists = bundle?.path(forResource: sectionName, ofType: "nib") != nil
+        let isNibFileExists = bundle.path(forResource: sectionName, ofType: "nib") != nil
         if isNibFileExists {
             _ = SelfTableViewManagerCache.shared().loadNib(path: sectionName, owner: self, bundleURL: bundleURL)
             sectionView = controllerSection!

--- a/SelfTableViewManager/Classes/SelfTableViewManager.swift
+++ b/SelfTableViewManager/Classes/SelfTableViewManager.swift
@@ -251,11 +251,8 @@ extension SelfTableViewManager {
         
         allRows.removeObjects(in: discardRows)
         
-        if #available(iOS 11.0, *) {
-            performBatchUpdatesRemoveRows(paths: paths, allRows: allRows, animation: animation)
-        } else {
-            performBeginUpdatesRemoveRows(paths: paths, allRows: allRows, animation: animation)
-        }
+        rows = allRows as [AnyObject]
+        deleteRows(at: paths, with: animation)
     }
 
     /// Insert cells on top
@@ -284,47 +281,7 @@ extension SelfTableViewManager {
             }
         }
         
-        if #available(iOS 11.0, *) {
-            performBatchUpdatesInsertRows(paths: paths, animation: animation)
-        } else {
-            performBeginUpdatesInsertRows(paths: paths, animation: animation)
-        }
-        
-    }
-    
-}
-
-// MARK: - content manipulation
-extension SelfTableViewManager {
-    @available(iOS 11.0, *)
-    internal func performBatchUpdatesRemoveRows(paths: [IndexPath], allRows: NSArray, animation: UITableView.RowAnimation) {
-        performBatchUpdates({
-            self.rows.removeAll()
-            self.rows = allRows as [AnyObject]
-            self.deleteRows(at: paths, with: animation)
-        })
-    }
-    
-    internal func performBeginUpdatesRemoveRows(paths: [IndexPath], allRows: NSArray, animation: UITableView.RowAnimation) {
-        beginUpdates()
-        self.rows.removeAll()
-        self.rows = allRows as [AnyObject]
-        self.deleteRows(at: paths, with: animation)
-        endUpdates()
-    }
-}
-
-// MARK: - content manipulation for insert cells
-extension SelfTableViewManager {
-    @available(iOS 11.0, *)
-    internal func performBatchUpdatesInsertRows(paths: [IndexPath], animation: UITableView.RowAnimation) {
-        performBatchUpdates({ self.insertRows(at: paths, with: animation) })
-    }
-    
-    internal func performBeginUpdatesInsertRows(paths: [IndexPath], animation: UITableView.RowAnimation) {
-        beginUpdates()
-        self.insertRows(at: paths, with: animation)
-        endUpdates()
+        insertRows(at: paths, with: animation)
     }
 }
 

--- a/SelfTableViewManager/Classes/SelfTableViewManager.swift
+++ b/SelfTableViewManager/Classes/SelfTableViewManager.swift
@@ -478,7 +478,7 @@ open class CellController: NSObject {
     
     private var bundle: Bundle? {
         guard let bundleURL = bundleURL,
-              let url = URL(string: bundleURL) else { return Bundle.main }
+              let url = URL(string: bundleURL) else { return Bundle(for: type(of: self)) }
         return Bundle(url: url)
     }
 
@@ -612,7 +612,7 @@ open class SectionController: NSObject {
     
     private var bundle: Bundle? {
         guard let bundleURL = bundleURL,
-              let url = URL(string: bundleURL) else { return Bundle.main }
+              let url = URL(string: bundleURL) else { return Bundle(for: type(of: self)) }
         return Bundle(url: url)
     }
     


### PR DESCRIPTION
### Problem
The crash was occurring when trying to remove multiple cells at the same time. Since the rows were being updated on performBatchUpdates method and it was executed async the rows array could become outdated and have a concurrent problem. 

### Solution
Since only one operation was being done in the [performBatchUpdates](https://developer.apple.com/documentation/uikit/uitableview/2887515-performbatchupdates), it was no longer needed and I removed it.